### PR TITLE
chore: Remove support of rust beta and nightly in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: rust
 
 rust:
   - stable
-  - beta
-  - nightly
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Remove support of rust beta and nightly in travis 